### PR TITLE
Unique outname

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# vistalab/qa_report_fmri
+# scitran/qa_report_fmri
 #
 # Use modified CNI/NIMS code from @rfdougherty to create a qa_report for a given fmri NIfTI file in Flywheel spec.
 # See https://github.com/cni/nims/blob/master/nimsproc/qa_report.py for original source code.
@@ -10,46 +10,13 @@
 #        scitran/qa-report-fmri /flywheel/v0/input -i nifti_file.nii.gz
 #
 
-FROM ubuntu-debootstrap:trusty
+FROM scitran/qa-report-fmri:v0
 
 MAINTAINER Michael Perry <lmperry@stanford.edu>
-
-# Install dependencies
-RUN apt-get update && apt-get -y install \
-    python-dev \
-    python-pip \
-    git \
-    libjpeg-dev \
-    zlib1g-dev \
-    pkg-config \
-    libpng12-dev \
-    libfreetype6-dev \
-    libblas-dev \
-    liblapack-dev \
-    libatlas-base-dev \
-    gfortran \
-    zip \
-    unzip
-
-# Link libs: pillow jpegi and zlib support hack
-RUN ln -s /usr/lib/x86_64-linux-gnu/libjpeg.so /usr/lib
-RUN ln -s /usr/lib/x86_64-linux-gnu/libz.so /usr/lib
-
-# Install scitran.data dependencies
-RUN  pip install pip==8.1.2 \
-    && pip install numpy==1.11.0 \
-    && pip install scipy==0.17.1 \
-    && pip install dipy==0.11.0 \
-    && pip install nibabel==2.0.2 \
-    && pip install nipy==0.4.0 \
-    && pip install matplotlib==1.5.1
 
 # Trigger build of font cache
 RUN python -c "from matplotlib import font_manager"
 
-# Make directory for flywheel spec (v0)
-ENV FLYWHEEL /flywheel/v0
-RUN mkdir -p ${FLYWHEEL}
 COPY run ${FLYWHEEL}/run
 COPY manifest.json ${FLYWHEEL}/manifest.json
 
@@ -57,4 +24,3 @@ COPY manifest.json ${FLYWHEEL}/manifest.json
 COPY qa-report-fmri.py ${FLYWHEEL}/qa_report.py
 
 ENTRYPOINT ["/flywheel/v0/run"]
-

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Builds the container.
 # The container can be exported using the export.sh script
-GEAR=scitran/qa-report-fmri
+GEAR=scitran/qa-report-fmri:v0.1.7
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 docker build --no-cache --tag $GEAR $DIR

--- a/export.sh
+++ b/export.sh
@@ -2,7 +2,7 @@
 # Exports the container in the cwd.
 # The container can be exported once it's started with
 
-version=0.1.6
+version=0.1.7
 container=qa-report-fmri
 outname=$container-$version.tar
 image=scitran/$container

--- a/manifest.json
+++ b/manifest.json
@@ -1,24 +1,26 @@
 {
-	"name": "qa-report-fmri",
-	"label": "Quality Assurance Report (fMRI)",
-	"description": "Run QA metrics (displacement, signal spikes) to create a quality assurance report (png) for an fMRI NIfTI using modified CNI/NIMS code from @rfdougherty.",
-	"maintainer": "Michael Perry <lmperry@stanford.edu>",
-	"author": "Robert F. Dougherty",
-	"url": "https://github.com/cni/nims/blob/master/nimsproc/qa_report.py",
-	"source": "https://github.com/scitran-apps/qa-report-fmri",
-	"license": "Apache-2.0",
-	"flywheel": "0",
-	"version": "0.1.6",
-	"config": {},
-	"inputs": {
-		"nifti": {
-			"base": "file",
-			"type": {
-				"enum": ["nifti"]
-			}
-		}
-	},
-	"custom": {
-		"docker-image": "scitran/qa-report-fmri"
-	}
+  "name": "qa-report-fmri",
+  "label": "Quality Assurance Report (fMRI)",
+  "description": "Run QA metrics (displacement, signal spikes) to create a quality assurance report (png) for an fMRI NIfTI using modified CNI/NIMS code from @rfdougherty.",
+  "maintainer": "Michael Perry <lmperry@stanford.edu>",
+  "author": "Robert F. Dougherty",
+  "url": "https://github.com/cni/nims/blob/master/nimsproc/qa_report.py",
+  "source": "https://github.com/scitran-apps/qa-report-fmri",
+  "license": "Apache-2.0",
+  "flywheel": "0",
+  "version": "0.1.7",
+  "config": {},
+  "inputs": {
+    "nifti": {
+      "base": "file",
+      "type": {
+        "enum": [
+          "nifti"
+        ]
+      }
+    }
+  },
+  "custom": {
+    "docker-image": "scitran/qa-report-fmri:v0.1.7"
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -13,6 +13,7 @@
   "inputs": {
     "nifti": {
       "base": "file",
+      "description": "Functional NIfTI data file.",
       "type": {
         "enum": [
           "nifti"

--- a/qa-report-fmri.py
+++ b/qa-report-fmri.py
@@ -208,8 +208,7 @@ def generate_qa_report(nifti_file, nifti_path, force=False, spike_thresh=6., nsk
         except:
             median_tsnr = np.ma.median(0)
 
-
-        qa_filenames = [u'qa_report.json', u'qa_report.png']
+        qa_filenames = [os.path.basename(nifti_file).split('.')[0] + u'_qa_report.json', os.path.basename(nifti_file).split('.')[0] + u'_qa_report.png']
 
         json_file = os.path.join(nifti_path, qa_filenames[0])
         print("%s nifti file (%s) QA: writing report to %s..." % (time.asctime(), nifti_file, json_file))
@@ -251,5 +250,3 @@ class ArgumentParser(argparse.ArgumentParser):
 if __name__ == '__main__':
     args = ArgumentParser().parse_args()
     generate_qa_report(args.nifti_file, args.nifti_path, force=args.force, spike_thresh=args.spike_thresh, nskip=args.nskip)
-
-


### PR DESCRIPTION
Don't use a standard output name, rather default to the input NIfTI filename + '_qa_report.png'